### PR TITLE
ci: run cs9 anaconda test on Fedora 39 runner

### DIFF
--- a/.github/workflows/anaconda.yml
+++ b/.github/workflows/anaconda.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: CentOS-Stream-9
+          compose: Fedora-39
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
@@ -152,7 +152,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: CentOS-Stream-9
+          compose: Fedora-39
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}


### PR DESCRIPTION
Libvirt and qemu-kvm on CS9 can't work well with httpboot. Let's change CS9 anadonda test runner to Fedora 39