### PR TITLE
playbooks/install: Drop skopeo dependency

### DIFF
--- a/playbooks/install.yaml
+++ b/playbooks/install.yaml
@@ -25,11 +25,10 @@
       command: findmnt
       ignore_errors: true
 
-    - name: Install podman and skopeo
+    - name: Install podman
       dnf:
         name:
           - podman
-          - skopeo
         state: present
       become: true
       when: ('rhel' not in test_os) or (platform != 'aws')

--- a/playbooks/install.yaml
+++ b/playbooks/install.yaml
@@ -34,13 +34,12 @@
       become: true
       when: ('rhel' not in test_os) or (platform != 'aws')
 
-    - name: Install podman and skopeo from internal
+    - name: Install podman from internal
       dnf:
         disablerepo: "*"
         enablerepo: "rhel-94-*"
         name:
           - podman
-          - skopeo
         state: present
       become: true
       when:
@@ -62,6 +61,7 @@
          --privileged \
          --pid=host \
          -v /:/target \
+         -v /var/lib/containers:/var/lib/containers \
          --security-opt label=type:unconfined_t \
          {{ test_image_url }} \
          bootc install to-filesystem --replace=alongside /target"


### PR DESCRIPTION
Bind mounting `/var/lib/containers` should work with the latest bootc and is the recommendation.