### PR TITLE
test: install qemu-user-static as cross build dependency

### DIFF
--- a/.github/workflows/os-replace.yml
+++ b/.github/workflows/os-replace.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: RHEL-9.4.0-Nightly
+          compose: Fedora-latest
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
@@ -111,7 +111,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: CentOS-Stream-9
+          compose: Fedora-latest
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
@@ -149,7 +149,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: CentOS-Stream-9
+          compose: Fedora-latest
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}

--- a/tmt/plans/os-replace.fmf
+++ b/tmt/plans/os-replace.fmf
@@ -54,6 +54,10 @@ execute:
   adjust+:
     - when: arch != x86_64 and arch != aarch64
       enabled: false
+  prepare+:
+    - how: install
+      package:
+        - qemu-user-static
 
 /libvirt:
   summary: Run os-replace test locally (nested)


### PR DESCRIPTION
Corss building needs `qemu-user-static`. It should be installed in `prepare`.