### PR TITLE
Renovating fedora to the latest supported release

### DIFF
--- a/.github/workflows/upload_rhel9_ami.yml
+++ b/.github/workflows/upload_rhel9_ami.yml
@@ -4,17 +4,18 @@ name: Upload RHEL9 AMI Image
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 23 * * 0,3'
+    - cron: "30 23 * * 0,3"
 
 jobs:
   update_ami:
     runs-on: container-runner
+    # renovate: datasource=endoflife-date depName=fedora versioning=docker
     container: quay.io/fedora/fedora:39
     steps:
       - name: Install unzip and git
         run: sudo dnf install -y unzip git gh
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Get current date
         id: date
@@ -64,14 +65,14 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d  # v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: rebase
 
       - name: Add a comment to trigger test workflow
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           token: ${{ secrets.PAT }}
           issue-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,31 @@
     ":semanticCommits",
     ":semanticCommitTypeAll(ci)",
     ":semanticCommitScopeDisabled"
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": [
+        "quay.io/fedora/fedora"
+      ],
+      "matchManagers": [
+        "dockerfile",
+        "github-actions"
+      ],
+      "enabled": false
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "Containerfile$",
+        ".github/workflows/.*\\.yml$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) packageName=(?<packageName>.*?)( versioning=(?<versioning>.*?))?\\sFROM\\s(?<depName>.*?):(?<currentValue>.*)",
+        "#\\s+renovate:\\s+datasource=(?<datasource>.*?) packageName=(?<packageName>.*?)( versioning=(?<versioning>.*?))?\\s+container: (?<depName>.*?):(?<currentValue>.*)"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{/if}}"
+    }
   ]
 }

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,23 +1,24 @@
-FROM quay.io/fedora/fedora:41@sha256:220fde50fb85e7bd16ffe12167e91899dfee77bbbd04ff71a4db398866a7a8b5
+# renovate: datasource=endoflife-date depName=fedora versioning=docker
+FROM quay.io/fedora/fedora:39
 
 # Google Cloud SDK repo
 COPY google-cloud-sdk.repo /etc/yum.repos.d/
 
 RUN dnf -y update && \
     dnf -y install \
-        ansible-core \
-        beaker-client \
-        curl \
-        gcc \
-        google-cloud-cli \
-        net-tools \
-        podman \
-        procps-ng \
-        python3 \
-        python3-devel \
-        python3-pip \
-        skopeo \
-        unzip && \
+    ansible-core \
+    beaker-client \
+    curl \
+    gcc \
+    google-cloud-cli \
+    net-tools \
+    podman \
+    procps-ng \
+    python3 \
+    python3-devel \
+    python3-pip \
+    skopeo \
+    unzip && \
     dnf clean all && \
     pip install boto3 botocore openstacksdk && \
     ansible-galaxy collection install openstack.cloud community.general amazon.aws ansible.posix && \


### PR DESCRIPTION
Renovate will bump fedora image to the latest supported release for the Dockerfile and the github action workflow. See example: https://github.com/platform-engineering-org-test/renovate_test_2/pull/17