### PR TITLE
ci: do not run ami image update cronly but manually update instead

### DIFF
--- a/.github/workflows/update_cs9_ami.yml
+++ b/.github/workflows/update_cs9_ami.yml
@@ -3,8 +3,6 @@ name: Update CS9 AMI Image
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '30 0 * * 0'
 
 jobs:
   update_ami:

--- a/.github/workflows/upload_rhel9_ami.yml
+++ b/.github/workflows/upload_rhel9_ami.yml
@@ -3,8 +3,6 @@ name: Upload RHEL9 AMI Image
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '30 23 * * 0'
 
 jobs:
   update_ami:


### PR DESCRIPTION
This PR removed ami image cron update but use manual update instead.