### PR TITLE
[DO NOT MERGE] test: test osbuild PR#1673

### DIFF
--- a/bib-image.sh
+++ b/bib-image.sh
@@ -161,7 +161,7 @@ case "$IMAGE_TYPE" in
             --security-opt label=type:unconfined_t \
             --env AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
             --env AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-            quay.io/centos-bootc/bootc-image-builder:latest \
+            quay.io/xiaofwan/bootc-image-builder:osbuild \
             --type ami \
             --target-arch "$ARCH" \
             --aws-ami-name "$AMI_NAME" \
@@ -196,7 +196,7 @@ case "$IMAGE_TYPE" in
             --tls-verify=false \
             --security-opt label=type:unconfined_t \
             -v "$(pwd)/output":/output \
-            quay.io/centos-bootc/bootc-image-builder:latest \
+            quay.io/xiaofwan/bootc-image-builder:osbuild \
             --type qcow2 \
             --target-arch "$ARCH" \
             "$TEST_IMAGE_URL"
@@ -223,7 +223,7 @@ case "$IMAGE_TYPE" in
             --tls-verify=false \
             --security-opt label=type:unconfined_t \
             -v "$(pwd)/output":/output \
-            quay.io/centos-bootc/bootc-image-builder:latest \
+            quay.io/xiaofwan/bootc-image-builder:osbuild \
             --type vmdk \
             --target-arch "$ARCH" \
             "$TEST_IMAGE_URL"


### PR DESCRIPTION
Image `quay.io/xiaofwan/bootc-image-builder:osbuild` replaced osbuild inside image with https://download.copr.fedorainfracloud.org/results/%40osbuild/osbuild/fedora-39-x86_64/07189053-osbuild/ which includes https://github.com/osbuild/osbuild/pull/1673 fix. 