### PR TITLE
test: add beaker bare metal os replace test

### DIFF
--- a/.github/workflows/os-replace.yml
+++ b/.github/workflows/os-replace.yml
@@ -58,10 +58,12 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64]
-        platform: [openstack, gcp, aws, libvirt]
+        platform: [openstack, gcp, aws, libvirt, beaker]
         include:
           - arch: aarch64
             platform: aws
+          - arch: aarch64
+            platform: beaker
     runs-on: ubuntu-latest
 
     steps:
@@ -74,11 +76,11 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: RHEL-9.4.0-Nightly
+          compose: Fedora-Rawhide
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
-          arch: ${{ matrix.arch }}
+          arch: x86_64
           tmt_context: "arch=${{ matrix.arch }}"
           update_pull_request_status: true
           pull_request_status_name: "bootc-rhel94-${{ matrix.arch }}-replace-${{ matrix.platform }}"
@@ -96,10 +98,12 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64]
-        platform: [openstack, gcp, aws, libvirt]
+        platform: [openstack, gcp, aws, libvirt, beaker]
         include:
           - arch: aarch64
             platform: aws
+          - arch: aarch64
+            platform: beaker
     runs-on: ubuntu-latest
 
     steps:
@@ -112,11 +116,11 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: CentOS-Stream-9
+          compose: Fedora-Rawhide
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
-          arch: ${{ matrix.arch }}
+          arch: x86_64
           tmt_context: "arch=${{ matrix.arch }}"
           update_pull_request_status: true
           pull_request_status_name: "bootc-cs9-${{ matrix.arch }}-replace-${{ matrix.platform }}"
@@ -134,10 +138,12 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64]
-        platform: [openstack, gcp, aws, libvirt]
+        platform: [openstack, gcp, aws, libvirt, beaker]
         include:
           - arch: aarch64
             platform: aws
+          - arch: aarch64
+            platform: beaker
     runs-on: ubuntu-latest
 
     steps:
@@ -150,11 +156,11 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: CentOS-Stream-9
+          compose: Fedora-Rawhide
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
-          arch: ${{ matrix.arch }}
+          arch: x86_64
           tmt_context: "arch=${{ matrix.arch }}"
           update_pull_request_status: true
           pull_request_status_name: "bootc-cs9-dev-${{ matrix.arch }}-replace-${{ matrix.platform }}"

--- a/.github/workflows/os-replace.yml
+++ b/.github/workflows/os-replace.yml
@@ -62,8 +62,9 @@ jobs:
         include:
           - arch: aarch64
             platform: aws
-          - arch: aarch64
+          - arch: x86_64
             platform: beaker
+            firmware: bios
     runs-on: ubuntu-latest
 
     steps:
@@ -76,18 +77,18 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: Fedora-Rawhide
+          compose: RHEL-9.4.0-Nightly
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
-          arch: x86_64
+          arch: ${{ matrix.arch }}
           tmt_context: "arch=${{ matrix.arch }}"
           update_pull_request_status: true
           pull_request_status_name: "bootc-rhel94-${{ matrix.arch }}-replace-${{ matrix.platform }}"
           tmt_plan_regex: "${{ matrix.platform }}"
           tf_scope: private
-          secrets: "OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};RHEL_REGISTRY_URL=${{ secrets.RHEL_REGISTRY_URL }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};RHC_AK=${{ secrets.RHC_AK }};RHC_ORGID=${{ secrets.RHC_ORGID }}"
-          variables: "TEST_OS=rhel-9-4;PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }}"
+          secrets: "OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};RHEL_REGISTRY_URL=${{ secrets.RHEL_REGISTRY_URL }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};RHC_AK=${{ secrets.RHC_AK }};RHC_ORGID=${{ secrets.RHC_ORGID }};BEAKER_KEYTAB_B64=${{ secrets.BEAKER_KEYTAB_B64 }};BEAKER_CLIENT_B64=${{ secrets.BEAKER_CLIENT_B64 }};KRB5_CONF_B64=${{ secrets.KRB5_CONF_B64 }}"
+          variables: "TEST_OS=rhel-9-4;PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};FIRMWARE=${{ matrix.firmware }}"
 
   cs9-replace:
     needs: pr-info
@@ -102,8 +103,9 @@ jobs:
         include:
           - arch: aarch64
             platform: aws
-          - arch: aarch64
+          - arch: x86_64
             platform: beaker
+            firmware: bios
     runs-on: ubuntu-latest
 
     steps:
@@ -116,18 +118,18 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: Fedora-Rawhide
+          compose: CentOS-Stream-9
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
-          arch: x86_64
+          arch: ${{ matrix.arch }}
           tmt_context: "arch=${{ matrix.arch }}"
           update_pull_request_status: true
           pull_request_status_name: "bootc-cs9-${{ matrix.arch }}-replace-${{ matrix.platform }}"
           tmt_plan_regex: "${{ matrix.platform }}"
           tf_scope: private
-          secrets: "OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }}"
-          variables: "TEST_OS=centos-stream-9;PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }}"
+          secrets: "OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};BEAKER_KEYTAB_B64=${{ secrets.BEAKER_KEYTAB_B64 }};BEAKER_CLIENT_B64=${{ secrets.BEAKER_CLIENT_B64 }};KRB5_CONF_B64=${{ secrets.KRB5_CONF_B64 }}"
+          variables: "TEST_OS=centos-stream-9;PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};FIRMWARE=${{ matrix.firmware }}"
 
   cs9-dev-replace:
     needs: pr-info
@@ -144,6 +146,13 @@ jobs:
             platform: aws
           - arch: aarch64
             platform: beaker
+            firmware: uefi
+          - arch: x86_64
+            platform: beaker
+            firmware: uefi
+          - arch: x86_64
+            platform: beaker
+            firmware: bios
     runs-on: ubuntu-latest
 
     steps:
@@ -156,18 +165,18 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: Fedora-Rawhide
+          compose: CentOS-Stream-9
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
-          arch: x86_64
+          arch: ${{ matrix.arch }}
           tmt_context: "arch=${{ matrix.arch }}"
           update_pull_request_status: true
           pull_request_status_name: "bootc-cs9-dev-${{ matrix.arch }}-replace-${{ matrix.platform }}"
           tmt_plan_regex: "${{ matrix.platform }}"
           tf_scope: private
-          secrets: "OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }}"
-          variables: "TEST_OS=centos-stream-9;PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};IMAGE_NAME=centos-bootc-dev;OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }}"
+          secrets: "OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};BEAKER_KEYTAB_B64=${{ secrets.BEAKER_KEYTAB_B64 }};BEAKER_CLIENT_B64=${{ secrets.BEAKER_CLIENT_B64 }};KRB5_CONF_B64=${{ secrets.KRB5_CONF_B64 }}"
+          variables: "TEST_OS=centos-stream-9;PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};IMAGE_NAME=centos-bootc-dev;OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};FIRMWARE=${{ matrix.firmware }}"
 
   rhel94-beta-replace:
     needs: pr-info

--- a/os-replace.sh
+++ b/os-replace.sh
@@ -50,7 +50,6 @@ yum_repos:
     enabled: true
     gpgcheck: false
 EOF
-        BARE_METAL_PARTITION="standard"
         ;;
     "centos-stream-9")
         IMAGE_NAME=${IMAGE_NAME:-"centos-bootc"}
@@ -63,10 +62,6 @@ EOF
             SSH_USER="ec2-user"
             REPLACE_CLOUD_USER='RUN sed -i "s/name: cloud-user/name: ec2-user/g" /etc/cloud/cloud.cfg'
         fi
-        BARE_METAL_PARTITION="standard"
-        if [[ "$IMAGE_NAME" == "centos-bootc-dev" ]]; then
-            BARE_METAL_PARTITION="lvm"
-        fi
         ;;
     "fedora-eln")
         IMAGE_NAME="fedora-bootc"
@@ -75,7 +70,6 @@ EOF
         SSH_USER="fedora"
         ADD_REPO=""
         ADD_RHC=""
-        BARE_METAL_PARTITION="lvm"
         ;;
     *)
         redprint "Variable TEST_OS has to be defined"
@@ -98,20 +92,6 @@ fi
 VERSION_ID=$(skopeo inspect --tls-verify=false "docker://${TIER1_IMAGE_URL}" | jq -r '.Labels."redhat.version-id"')
 TEST_IMAGE_NAME="${IMAGE_NAME}-os_replace"
 TEST_IMAGE_URL="quay.io/redhat_emp1/${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}"
-
-greenprint "Configure container build arch"
-case "$ARCH" in
-    "x86_64")
-        BUILD_PLATFORM="linux/amd64"
-        ;;
-    "aarch64")
-        BUILD_PLATFORM="linux/arm64"
-        ;;
-    *)
-        redprint "Variable ARCH has to be defined"
-        exit 1
-        ;;
-esac
 
 [[ $- =~ x ]] && debug=1 && set +x
 sed "s/REPLACE_ME/${QUAY_SECRET}/g" files/auth.template | tee "${LAYERED_DIR}"/auth.json > /dev/null
@@ -146,9 +126,9 @@ podman login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 
 greenprint "Build $TEST_OS installation container image"
 if [[ "$LAYERED_IMAGE" == "useradd-ssh" ]]; then
-    podman build --platform "$BUILD_PLATFORM" --tls-verify=false --retry=5 --retry-delay=10 --build-arg "sshpubkey=$(cat "${SSH_KEY_PUB}")" -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" "$LAYERED_DIR"
+    podman build --tls-verify=false --retry=5 --retry-delay=10 --build-arg "sshpubkey=$(cat "${SSH_KEY_PUB}")" -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" "$LAYERED_DIR"
 else
-    podman build --platform "$BUILD_PLATFORM" --tls-verify=false --retry=5 --retry-delay=10 -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" "$LAYERED_DIR"
+    podman build --tls-verify=false --retry=5 --retry-delay=10 -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" "$LAYERED_DIR"
 fi
 
 greenprint "Push $TEST_OS installation container image"
@@ -190,7 +170,6 @@ greenprint "Install $TEST_OS bootc system"
 ansible-playbook -v \
     -i "$INVENTORY_FILE" \
     -e test_image_url="$TEST_IMAGE_URL" \
-    -e bare_metal_partition="$BARE_METAL_PARTITION" \
     playbooks/install.yaml
 
 if [[ "$PLATFORM" == "libvirt" ]] && [[ "$LAYERED_IMAGE" == "qemu-guest-agent" ]]; then
@@ -213,7 +192,7 @@ RUN dnf -y install wget && \
 EOF
 
 greenprint "Build $TEST_OS upgrade container image"
-podman build --platform "$BUILD_PLATFORM" --tls-verify=false --retry=5 --retry-delay=10 -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" -f "$UPGRADE_CONTAINERFILE" .
+podman build --tls-verify=false --retry=5 --retry-delay=10 -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" -f "$UPGRADE_CONTAINERFILE" .
 greenprint "Push $TEST_OS upgrade container image"
 retry podman push --tls-verify=false --quiet "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" "$TEST_IMAGE_URL"
 

--- a/playbooks/check-system.yaml
+++ b/playbooks/check-system.yaml
@@ -545,13 +545,14 @@
       when: "'rhel' in test_os"
 
     # case: check system reboot
+    # 5 minutes reboot timeout is for bare metal test
     - name: check system reboot
       block:
         - name: check system reboot
           reboot:
             post_reboot_delay: 60
             pre_reboot_delay: 60
-            reboot_timeout: 180
+            reboot_timeout: 300
           become: true
           ignore_errors: true
 

--- a/playbooks/check-system.yaml
+++ b/playbooks/check-system.yaml
@@ -545,14 +545,14 @@
       when: "'rhel' in test_os"
 
     # case: check system reboot
-    # 5 minutes reboot timeout is for bare metal test
+    # 10 minutes reboot timeout is for bare metal test
     - name: check system reboot
       block:
         - name: check system reboot
           reboot:
             post_reboot_delay: 60
             pre_reboot_delay: 60
-            reboot_timeout: 300
+            reboot_timeout: 600
           become: true
           ignore_errors: true
 

--- a/playbooks/deploy-beaker.yaml
+++ b/playbooks/deploy-beaker.yaml
@@ -1,0 +1,115 @@
+---
+- hosts: cloud
+  gather_facts: false
+  become: false
+  vars:
+    test_os: "{{ lookup('env', 'TEST_OS') | default('centos-stream-9', true) }}"
+    arch: "{{ lookup('env', 'ARCH') | default('x86_64', true) }}"
+    ssh_user: ""
+    ssh_key_pub: ""
+    inventory_file: ""
+    bare_metal_partition: "standard"
+    beaker_family:
+      rhel-9-4: RedHatEnterpriseLinux9
+      centos-stream-9: CentOSStream9
+    beaker_compose:
+      # avoid rhel-9.4.0-updates-2024xxxx.xx
+      rhel-9-4: rhel-9.4.0-20
+      centos-stream-9: CentOS-Stream-9
+
+  tasks:
+    - name: "get latest {{ beaker_family[test_os] }} distro"
+      command: bkr distros-list --family {{ beaker_family[test_os] }} --name {{ beaker_compose[test_os] }}% --tag CTS_NIGHTLY --limit 1 --format json
+      register: distro_result_rhel
+      when: "'rhel' in test_os"
+
+    - name: "get latest {{ beaker_family[os] }} distro"
+      command: bkr distros-list --family {{ beaker_family[test_os] }} --name {{ beaker_compose[test_os] }}% --limit 1 --format json
+      register: distro_result_other
+      when: "'rhel' not in test_os"
+
+    - name: json format for rhel
+      set_fact:
+        tmp_result: "{{ distro_result_rhel.stdout | from_json }}"
+      when: "'rhel' in test_os"
+
+    - name: json format for others
+      set_fact:
+        tmp_result: "{{ distro_result_other.stdout | from_json }}"
+      when: "'rhel' not in test_os"
+
+    - name: set latest distro name
+      set_fact:
+        distro_name: "{{ tmp_result[0].distro_name }}"
+
+    - name: generate job xml
+      template:
+        src: beaker-job.j2
+        dest: beaker-job.xml
+
+    - name: submit beaker job
+      command: bkr job-submit beaker-job.xml
+      register: job_result
+
+    - name: got job id
+      set_fact:
+        job_id: "{{ job_result.stdout.split(\"'\")[1] }}"
+
+    - name: wait for job complete
+      command: bkr job-results --prettyxml {{ job_id }}
+      register: job_finished
+      retries: 50
+      delay: 60
+      until: "'result=\"Pass\" status=\"Running\"' in job_finished.stdout"
+      ignore_errors: true
+
+    - name: write job-results output to xml file
+      copy:
+        content: "{{ job_finished.stdout }}"
+        dest: job-result-output.xml
+
+    - name: get hostname from job-results output
+      xml:
+        path: job-result-output.xml
+        xpath: /job/recipeSet/recipe
+        content: attribute
+      register: recipe_attribute
+
+    - set_fact:
+        instance_ip: "{{ recipe_attribute.matches[0].recipe.system }}"
+
+    - name: Waits until instance is reachable
+      wait_for:
+        host: "{{ instance_ip }}"
+        port: 22
+        search_regex: OpenSSH
+        delay: 10
+      retries: 30
+      register: result_ssh_check
+      until: result_ssh_check is success
+
+    - name: Add instance ip into host group guest
+      add_host:
+        name: "{{ instance_ip }}"
+        groups: guest
+
+    - name: Wait 10 seconds for VM
+      wait_for:
+        timeout: 10
+      delegate_to: localhost
+
+    - name: Write instance ip to inventory file
+      community.general.ini_file:
+        path: "{{ inventory_file }}"
+        section: guest
+        option: guest ansible_host
+        value: "{{ instance_ip }}"
+        no_extra_spaces: true
+
+    - name: Write instance name to inventory file
+      community.general.ini_file:
+        path: "{{ inventory_file }}"
+        section: cloud:vars
+        option: job_id
+        value: "{{ job_id }}"
+        no_extra_spaces: true

--- a/playbooks/deploy-beaker.yaml
+++ b/playbooks/deploy-beaker.yaml
@@ -8,7 +8,7 @@
     ssh_user: ""
     ssh_key_pub: ""
     inventory_file: ""
-    bare_metal_partition: "standard"
+    firmware: "{{ lookup('env', 'FIRMWARE') | default('uefi', true) }}"
     beaker_family:
       rhel-9-4: RedHatEnterpriseLinux9
       centos-stream-9: CentOSStream9

--- a/playbooks/install.yaml
+++ b/playbooks/install.yaml
@@ -45,7 +45,7 @@
         - "'rhel' in test_os"
         - platform == "aws"
 
-    - name: Auth for RHEL private image
+    - name: Auth for private image
       command:
         podman login \
         -u "{{ lookup('env', 'QUAY_USERNAME') }}" \
@@ -62,7 +62,23 @@
       register: result
       until: result is successful
 
-    - name: Install image
+    # The latest bootc is only available in centos-bootc-dev image
+    - name: Install image with latest bootc
+      command:
+        "podman run \
+         --rm \
+         --privileged \
+         --pid=host \
+         -v /:/target \
+         -v /dev:/dev \
+         -v /var/lib/containers:/var/lib/containers \
+         --security-opt label=type:unconfined_t \
+         {{ test_image_url }} \
+         bootc install to-existing-root"
+      become: true
+      when: "'centos-bootc-dev' in test_image_url"
+
+    - name: Install image with released bootc
       command:
         "podman run \
          --rm \
@@ -74,11 +90,13 @@
          {{ test_image_url }} \
          bootc install to-filesystem --replace=alongside /target"
       become: true
+      when: "'centos-bootc-dev' not in test_image_url"
 
+    # 5 minutes reboot timeout is for bare metal test
     - name: Reboot to deploy new system
       reboot:
         post_reboot_delay: 60
-        reboot_timeout: 180
+        reboot_timeout: 600
       become: true
       ignore_errors: true
 

--- a/playbooks/install.yaml
+++ b/playbooks/install.yaml
@@ -92,7 +92,7 @@
       become: true
       when: "'centos-bootc-dev' not in test_image_url"
 
-    # 5 minutes reboot timeout is for bare metal test
+    # 10 minutes reboot timeout is for bare metal test
     - name: Reboot to deploy new system
       reboot:
         post_reboot_delay: 60

--- a/playbooks/remove.yaml
+++ b/playbooks/remove.yaml
@@ -65,3 +65,9 @@
             state: absent
           when: ami_id != ""
       when: platform == "aws"
+
+    - name: Cancel beaker job
+      block:
+        - name: "cancel beaker job {{ job_id }}"
+          command: bkr job-cancel "{{ job_id }}"
+      when: platform == "beaker"

--- a/playbooks/rollback.yaml
+++ b/playbooks/rollback.yaml
@@ -10,10 +10,11 @@
       command: rpm-ostree rollback
       become: true
 
+    # 5 minutes reboot timeout is for bare metal test
     - name: Reboot to deploy new system
       reboot:
         post_reboot_delay: 60
-        reboot_timeout: 180
+        reboot_timeout: 300
       become: true
       ignore_errors: true
 

--- a/playbooks/rollback.yaml
+++ b/playbooks/rollback.yaml
@@ -10,11 +10,11 @@
       command: rpm-ostree rollback
       become: true
 
-    # 5 minutes reboot timeout is for bare metal test
+    # 10 minutes reboot timeout is for bare metal test
     - name: Reboot to deploy new system
       reboot:
         post_reboot_delay: 60
-        reboot_timeout: 300
+        reboot_timeout: 600
       become: true
       ignore_errors: true
 

--- a/playbooks/templates/beaker-job.j2
+++ b/playbooks/templates/beaker-job.j2
@@ -1,0 +1,51 @@
+<job group='rhel-edge'>
+  <whiteboard>Provisioned for {{ arch }} bootc install test</whiteboard>
+  <recipeSet>
+    <recipe kernel_options="" kernel_options_post="" ks_meta="no_autopart" role="None" whiteboard="">
+      <autopick random="false"/>
+      <watchdog panic="None"/>
+      <packages/>
+      <ks_appends>
+        <ks_append><![CDATA[
+user --name={{ ssh_user }} --groups=wheel --iscrypted
+sshkey --username={{ ssh_user }} "{{ lookup('ansible.builtin.file', ssh_key_pub) }}"
+zerombr
+clearpart --all --initlabel --disklabel=gpt
+{% if bare_metal_partition == "lvm" %}
+part biosboot --size=1 --fstype=biosboot
+part /boot --size=1000 --fstype=ext4 --label=boot
+part pv.01 --grow
+volgroup bootc pv.01
+logvol / --vgname=bootc --fstype=xfs --size=10000 --name=root
+{% else %}
+autopart --type=plain --fstype=xfs
+{% endif %}
+%packages
+podman
+python3
+python3-dnf
+%end
+%post
+echo -e '{{ ssh_user }}\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
+%end
+        ]]></ks_append>
+      </ks_appends>
+      <repos/>
+      <distroRequires>
+        <and>
+          <distro_name op="=" value="{{ distro_name }}"/>
+          <distro_arch op="=" value="{{ arch }}"/>
+        </and>
+      </distroRequires>
+      <hostRequires>
+        <and>
+          <arch op="=" value="{{ arch }}"/>
+          <hypervisor op="=" value=""/>
+        </and>
+      </hostRequires>
+      <partitions/>
+      <task name="/distribution/check-install" role="STANDALONE"/>
+      <task name="/distribution/reservesys" role="STANDALONE"/>
+    </recipe>
+  </recipeSet>
+</job>

--- a/playbooks/templates/beaker-job.j2
+++ b/playbooks/templates/beaker-job.j2
@@ -1,5 +1,5 @@
 <job group='rhel-edge'>
-  <whiteboard>Provisioned for {{ arch }} bootc install test</whiteboard>
+  <whiteboard>bootc install test on {{ arch }} bare metal server </whiteboard>
   <recipeSet>
     <recipe kernel_options="" kernel_options_post="" ks_meta="no_autopart" role="None" whiteboard="">
       <autopick random="false"/>
@@ -11,9 +11,9 @@ user --name={{ ssh_user }} --groups=wheel --iscrypted
 sshkey --username={{ ssh_user }} "{{ lookup('ansible.builtin.file', ssh_key_pub) }}"
 zerombr
 clearpart --all --initlabel --disklabel=gpt
-{% if bare_metal_partition == "lvm" %}
-part biosboot --size=1 --fstype=biosboot
-part /boot --size=1000 --fstype=ext4 --label=boot
+{% if firmware == 'uefi' or arch == 'aarch64' %}
+part /boot/efi --size=100  --fstype=efi
+part /boot     --size=1000  --fstype=ext4 --label=boot
 part pv.01 --grow
 volgroup bootc pv.01
 logvol / --vgname=bootc --fstype=xfs --size=10000 --name=root
@@ -41,6 +41,9 @@ echo -e '{{ ssh_user }}\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
         <and>
           <arch op="=" value="{{ arch }}"/>
           <hypervisor op="=" value=""/>
+{% if firmware == 'uefi' and arch == 'x86_64' %}
+          <key_value key="NETBOOT_METHOD" op="=" value="efigrub"/>
+{% endif %}
         </and>
       </hostRequires>
       <partitions/>

--- a/playbooks/upgrade.yaml
+++ b/playbooks/upgrade.yaml
@@ -29,11 +29,11 @@
       when:
         - air_gapped_dir | default('') == ""
 
-    # 5 minutes reboot timeout is for bare metal test
+    # 10 minutes reboot timeout is for bare metal test
     - name: Reboot to deploy new system
       reboot:
         post_reboot_delay: 60
-        reboot_timeout: 300
+        reboot_timeout: 600
       become: true
       ignore_errors: true
 

--- a/playbooks/upgrade.yaml
+++ b/playbooks/upgrade.yaml
@@ -29,10 +29,11 @@
       when:
         - air_gapped_dir | default('') == ""
 
+    # 5 minutes reboot timeout is for bare metal test
     - name: Reboot to deploy new system
       reboot:
         post_reboot_delay: 60
-        reboot_timeout: 180
+        reboot_timeout: 300
       become: true
       ignore_errors: true
 

--- a/tmt/plans/os-replace.fmf
+++ b/tmt/plans/os-replace.fmf
@@ -81,3 +81,18 @@ execute:
         hardware:
           virtualization:
             is-supported: true
+
+/beaker:
+  summary: Run os-replace test on bare metal beaker server
+  tag: beaker
+  environment+:
+    PLATFORM: beaker
+    LAYERED_IMAGE: useradd-ssh
+  prepare+:
+    - how: install
+      package:
+        - beaker-client
+        - krb5-workstation
+  adjust+:
+    - when: arch != x86_64 and arch != aarch64
+      enabled: false

--- a/tmt/tests/os-replace.fmf
+++ b/tmt/tests/os-replace.fmf
@@ -1,4 +1,4 @@
 test: ./test.sh
-duration: 45m
+duration: 90m
 environment:
   TEST_CASE: os-replace

--- a/tmt/tests/test.sh
+++ b/tmt/tests/test.sh
@@ -6,6 +6,9 @@ TEMPDIR=$(mktemp -d)
 trap 'rm -rf -- "$TEMPDIR"' EXIT
 [[ $- =~ x ]] && debug=1 && set +x
 [[ -n "${GCP_SERVICE_ACCOUNT_FILE_B64+x}" ]] && echo "$GCP_SERVICE_ACCOUNT_FILE_B64" | base64 -d > "${TEMPDIR}"/gcp_auth.json && export GCP_SERVICE_ACCOUNT_FILE=${TEMPDIR}/gcp_auth.json
+[[ -n "${BEAKER_KEYTAB_B64+x}" ]] && echo "$BEAKER_KEYTAB_B64" | base64 -d > "${TEMPDIR}/beaker.keytab" && sudo mv "${TEMPDIR}/beaker.keytab" /etc/beaker.keytab
+[[ -n "${BEAKER_CLIENT_B64+x}" ]] && echo "$BEAKER_CLIENT_B64" | base64 -d > "${TEMPDIR}/client.conf" && sudo mv "${TEMPDIR}/client.conf" /etc/beaker/client.conf
+[[ -n "${KRB5_CONF_B64+x}" ]] && echo "$KRB5_CONF_B64" | base64 -d > "${TEMPDIR}/krb5.conf" && sudo mv "${TEMPDIR}/krb5.conf" /etc/krb5.conf
 [[ $debug == 1 ]] && set -x
 
 function run_tests() {


### PR DESCRIPTION
This PR adds os replace test on bare metal server from beaker. It covered bootc install for bare metal server scenario.
This PR only support standard partition. Will support LVM later.

- x86_64+BIOS+autopart+CS9: http://artifacts.osci.redhat.com/testing-farm/fcf46306-cdfb-48c0-a2c4-fe1c1c1640ad/

Let's run some regression tests.