### PR TITLE
ci: run all CS9 test on Fedora 40

### DIFF
--- a/.github/workflows/anaconda.yml
+++ b/.github/workflows/anaconda.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: Fedora-39
+          compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
@@ -152,7 +152,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: Fedora-39
+          compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}

--- a/.github/workflows/bib-image.yml
+++ b/.github/workflows/bib-image.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: CentOS-Stream-9
+          compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
@@ -180,7 +180,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: Fedora-Rawhide
+          compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}

--- a/.github/workflows/os-replace.yml
+++ b/.github/workflows/os-replace.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: CentOS-Stream-9
+          compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
@@ -149,7 +149,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: CentOS-Stream-9
+          compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}


### PR DESCRIPTION
Avoid TF CS9 runner deployment issue