### PR TITLE
test: run bootc-image-builder:9.4 beta container image test

### DIFF
--- a/bib-image.sh
+++ b/bib-image.sh
@@ -164,7 +164,7 @@ case "$IMAGE_TYPE" in
             --security-opt label=type:unconfined_t \
             --env AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
             --env AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-            quay.io/centos-bootc/bootc-image-builder:latest \
+            quay.io/xiaofwan/bootc-image-builder:9.4 \
             --type ami \
             --target-arch "$ARCH" \
             --aws-ami-name "$AMI_NAME" \
@@ -199,7 +199,7 @@ case "$IMAGE_TYPE" in
             --tls-verify=false \
             --security-opt label=type:unconfined_t \
             -v "$(pwd)/output":/output \
-            quay.io/centos-bootc/bootc-image-builder:latest \
+            quay.io/xiaofwan/bootc-image-builder:9.4 \
             --type qcow2 \
             --target-arch "$ARCH" \
             "$TEST_IMAGE_URL"
@@ -226,7 +226,7 @@ case "$IMAGE_TYPE" in
             --tls-verify=false \
             --security-opt label=type:unconfined_t \
             -v "$(pwd)/output":/output \
-            quay.io/centos-bootc/bootc-image-builder:latest \
+            quay.io/xiaofwan/bootc-image-builder:9.4 \
             --type vmdk \
             --target-arch "$ARCH" \
             "$TEST_IMAGE_URL"


### PR DESCRIPTION
- This version does not support `vmdk`