### PR TITLE
ci: rollback testing farm action to v1

### DIFF
--- a/.github/workflows/anaconda.yml
+++ b/.github/workflows/anaconda.yml
@@ -73,7 +73,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v1
         with:
           compose: RHEL-9.4.0-Nightly
           api_key: ${{ secrets.TF_API_KEY }}
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v1
         with:
           compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}
@@ -151,7 +151,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v1
         with:
           compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v1
         with:
           compose: RHEL-9.4.0-Nightly
           api_key: ${{ secrets.TF_API_KEY }}

--- a/.github/workflows/bib-image.yml
+++ b/.github/workflows/bib-image.yml
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v1
         with:
           compose: RHEL-9.4.0-Nightly
           api_key: ${{ secrets.TF_API_KEY }}
@@ -124,7 +124,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v1
         with:
           compose: CentOS-Stream-9
           api_key: ${{ secrets.TF_API_KEY }}
@@ -178,7 +178,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v1
         with:
           compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}

--- a/.github/workflows/os-replace.yml
+++ b/.github/workflows/os-replace.yml
@@ -75,7 +75,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v1
         with:
           compose: RHEL-9.4.0-Nightly
           api_key: ${{ secrets.TF_API_KEY }}
@@ -116,7 +116,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v1
         with:
           compose: CentOS-Stream-9
           api_key: ${{ secrets.TF_API_KEY }}
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v1
         with:
           compose: CentOS-Stream-9
           api_key: ${{ secrets.TF_API_KEY }}
@@ -200,7 +200,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run the tests
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v1
         with:
           compose: RHEL-9.4.0-Nightly
           api_key: ${{ secrets.TF_API_KEY }}


### PR DESCRIPTION
It's due to issue https://github.com/sclorg/testing-farm-as-github-action/pull/137#issuecomment-2039397156