### PR TITLE
test: fix cs9 image regex and glaxy server unstable issues

### DIFF
--- a/playbooks/deploy-beaker.yaml
+++ b/playbooks/deploy-beaker.yaml
@@ -19,12 +19,12 @@
 
   tasks:
     - name: "get latest {{ beaker_family[test_os] }} distro"
-      command: bkr distros-list --family {{ beaker_family[test_os] }} --name {{ beaker_compose[test_os] }}% --tag CTS_NIGHTLY --limit 1 --format json
+      command: bkr distros-list --insecure --family {{ beaker_family[test_os] }} --name {{ beaker_compose[test_os] }}% --tag CTS_NIGHTLY --limit 1 --format json
       register: distro_result_rhel
       when: "'rhel' in test_os"
 
     - name: "get latest {{ beaker_family[test_os] }} distro"
-      command: bkr distros-list --family {{ beaker_family[test_os] }} --name {{ beaker_compose[test_os] }}% --limit 1 --format json
+      command: bkr distros-list --insecure --family {{ beaker_family[test_os] }} --name {{ beaker_compose[test_os] }}% --limit 1 --format json
       register: distro_result_other
       when: "'rhel' not in test_os"
 
@@ -48,7 +48,7 @@
         dest: beaker-job.xml
 
     - name: submit beaker job
-      command: bkr job-submit beaker-job.xml
+      command: bkr job-submit --insecure beaker-job.xml
       register: job_result
 
     - name: got job id
@@ -56,7 +56,7 @@
         job_id: "{{ job_result.stdout.split(\"'\")[1] }}"
 
     - name: wait for job complete
-      command: bkr job-results --prettyxml {{ job_id }}
+      command: bkr job-results --insecure --prettyxml {{ job_id }}
       register: job_finished
       retries: 50
       delay: 60

--- a/playbooks/deploy-libvirt.yaml
+++ b/playbooks/deploy-libvirt.yaml
@@ -23,7 +23,7 @@
     - name: Get CentOS-Stream-GenericCloud image filename
       block:
         - name: Get CentOS-Stream-GenericCloud image filename
-          shell: curl -s https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/{{ arch }}/images/ | grep -oP '(?<=href=")CentOS-Stream-GenericCloud-[^"]+.qcow2(?=")'
+          shell: curl -s https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/{{ arch }}/images/ | grep -oP '(?<=href=")CentOS-Stream-GenericCloud-(9|10)-[^"]+.qcow2(?=")'
           register: out
 
         - set_fact:

--- a/playbooks/remove.yaml
+++ b/playbooks/remove.yaml
@@ -95,7 +95,7 @@
     - name: Cancel beaker job
       block:
         - name: "cancel beaker job {{ job_id }}"
-          command: bkr job-cancel "{{ job_id }}"
+          command: bkr job-cancel --insecure "{{ job_id }}"
       when: platform == "beaker"
 
     - name: Remove Azure resource group

--- a/tmt/plans/anaconda.fmf
+++ b/tmt/plans/anaconda.fmf
@@ -24,8 +24,6 @@ prepare:
       - xorriso
   - how: shell
     script: ansible-galaxy collection install https://ansible-collection.s3.amazonaws.com/ansible-posix-1.5.4.tar.gz https://ansible-collection.s3.amazonaws.com/community-general-8.5.0.tar.gz
-  - how: shell
-    script: curl -kLO ${CERT_URL}/certs/Current-IT-Root-CAs.pem --output-dir /etc/pki/ca-trust/source/anchors && update-ca-trust
 execute:
   how: tmt
 


### PR DESCRIPTION
We have two issues recently:
1. CS9 builds two qcow2 images since `20240405.1`. That caused regrex failure. e.g. http://artifacts.osci.redhat.com/testing-farm/3a6eb0a5-ab17-4633-8e85-a563174dd903/
2. ansible galaxy server is not stable. Download collections filed a lot of times. e.g. http://artifacts.osci.redhat.com/testing-farm/9b4c02a8-301e-49de-b73c-5bdd3ca2d3d5/

This PR addresses those two issues.