### PR TITLE
Drop --no-signature-verification

### DIFF
--- a/anaconda.sh
+++ b/anaconda.sh
@@ -165,7 +165,7 @@ sshkey --username=${SSH_USER} "$SSH_KEY_PUB_CONTENT"
 
 bootloader --append="console=ttyS0,115200n8"
 
-ostreecontainer --url $TEST_IMAGE_URL --no-signature-verification
+ostreecontainer --url $TEST_IMAGE_URL
 
 poweroff
 


### PR DESCRIPTION
Not necessary anymore since https://github.com/ostreedev/ostree-rs-ext/commit/a5fadff0e8f8dca1ed06c82415feae27177f853f which is in 9.4