### PR TITLE
test: use cloud-init to deploy azure instance

### DIFF
--- a/playbooks/deploy-azure.yaml
+++ b/playbooks/deploy-azure.yaml
@@ -7,12 +7,14 @@
     arch: "{{ lookup('env', 'ARCH') | default('x86_64', true) }}"
     ssh_key_pub: ""
     ssh_user: "cloud-user"
+    platform: "{{ lookup('env', 'PLATFORM') | default('azure', true) }}"
     inventory_file: ""
     rg_image: "bootc-images"
     location: "eastus"
     vm_size:
       x86_64: Standard_D2ads_v5
       aarch64: Standard_D2pds_v5
+    bib: "false"
 
   tasks:
     - set_fact:
@@ -150,6 +152,11 @@
           --kind StorageV2 \
           --tags "project=bootc"
 
+    - name: Generate user-data
+      template:
+        src: user-data.j2
+        dest: "{{ playbook_dir }}/azure-user-data"
+
     - name: Create VM
       shell: |
         az vm create \
@@ -164,8 +171,7 @@
           --size {{ vm_size[arch] }} \
           --image {{ image_id }} \
           --boot-diagnostics-storage {{ sa_name }} \
-          --admin-username {{ ssh_user }} \
-          --ssh-key-values {{ ssh_key_pub }} \
+          --user-data "{{ playbook_dir }}/azure-user-data" \
           --generate-ssh-keys \
           --tags "project=bootc" \
           --no-wait

--- a/playbooks/templates/user-data.j2
+++ b/playbooks/templates/user-data.j2
@@ -1,7 +1,7 @@
 #cloud-config
 users:
   - default
-{% if platform == 'libvirt' %}
+{% if platform == 'libvirt' or platform == 'azure' %}
   - name: {{ ssh_user }}
     sudo: ALL=(ALL) NOPASSWD:ALL
     groups: sudo, wheel
@@ -9,7 +9,7 @@ users:
     ssh_authorized_keys:
       - {{ lookup('ansible.builtin.file', ssh_key_pub) }}
 {% endif %}
-{% if bib == 'false' and test_os.startswith('rhel') %}
+{% if bib == 'false' and (platform == 'openstack' or platform == 'libvirt') and test_os.startswith('rhel') %}
 yum_repos:
   rhel-94-baseos:
     name: rhel-94-baseos


### PR DESCRIPTION
According to https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/virtual-machines/user-data.md#what-is-user-data, the new `--user-data` can save user data into Azure Instance Metadata Service(IMDS).
We can use `--user-data` for bootc install test on Azure.