### PR TITLE
test: build rhel bootc image with bib

### DIFF
--- a/playbooks/check-system.yaml
+++ b/playbooks/check-system.yaml
@@ -82,6 +82,7 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
+      when: "'localhost' not in installed_image"
 
     # case: check ostree-remount service status
     - name: check ostree-remount service status

--- a/playbooks/rollback.yaml
+++ b/playbooks/rollback.yaml
@@ -34,6 +34,11 @@
           register: result_rollback_image_digest
           become: true
 
+        - name: determine installed image from localhost or quay.io
+          shell: bootc status --json | jq -r '.status.booted.image.image.image'
+          become: true
+          register: result_bootc_status
+
         - name: check booted cachedUpdate and rollback image digest
           block:
             - assert:
@@ -50,6 +55,7 @@
                 failed_counter: "{{ failed_counter | int + 1 }}"
           when:
             - air_gapped_dir | default('') == ""
+            - "'localhost' not in result_bootc_status.stdout"
 
         - name: check installed package
           shell: rpm -qa | sort

--- a/playbooks/upgrade.yaml
+++ b/playbooks/upgrade.yaml
@@ -1,6 +1,8 @@
 ---
 - hosts: guest
   become: false
+  vars:
+    bootc_image: ""
 
   tasks:
     - name: Air-gapped upgrade
@@ -23,11 +25,22 @@
       when:
         - air_gapped_dir | default('') != ""
 
+    - name: determine installed image from localhost or quay.io
+      shell: bootc status --json | jq -r '.status.booted.image.image.image'
+      become: true
+      register: result_bootc_status
+
+    - name: switch to quay.io for upgrade
+      command: bootc switch {{ bootc_image }}
+      become: true
+      when: "'localhost' in result_bootc_status.stdout"
+
     - name: bootc upgrade
       command: bootc upgrade
       become: true
       when:
         - air_gapped_dir | default('') == ""
+        - "'localhost' not in result_bootc_status.stdout"
 
     # 10 minutes reboot timeout is for bare metal test
     - name: Reboot to deploy new system
@@ -40,3 +53,7 @@
     - name: Wait for connection to become reachable/usable
       wait_for_connection:
         delay: 30
+
+    - name: bootc booted status
+      command: bootc status --booted
+      become: true


### PR DESCRIPTION
This PR uses `-v /var/lib/containers/storage:/var/lib/containers/storage` and `--local` to build RHEL image (private image repo). But it still needs to use `bootc switch` to do the first upgrade from container image registry, like quay.io. Otherwise system will upgrade from localhost.

@cgwalters This is the only solution to build cloud image from private image repo with bib.

cc @shi2wei3 