### PR TITLE
test: add auth to inspect private container image registry

### DIFF
--- a/anaconda.sh
+++ b/anaconda.sh
@@ -3,6 +3,7 @@ set -exuo pipefail
 
 source tools/shared_lib.sh
 dump_runner
+image_inspect
 
 greenprint "Start firewalld"
 sudo systemctl enable --now firewalld

--- a/bib-image.sh
+++ b/bib-image.sh
@@ -3,6 +3,7 @@ set -exuo pipefail
 
 source tools/shared_lib.sh
 dump_runner
+image_inspect
 
 TEMPDIR=$(mktemp -d)
 trap 'rm -rf -- "$TEMPDIR"' EXIT

--- a/os-replace.sh
+++ b/os-replace.sh
@@ -3,6 +3,7 @@ set -exuo pipefail
 
 source tools/shared_lib.sh
 dump_runner
+image_inspect
 
 TEMPDIR=$(mktemp -d)
 trap 'rm -rf -- "$TEMPDIR"' EXIT

--- a/tools/shared_lib.sh
+++ b/tools/shared_lib.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# shellcheck disable=SC2034
-REDHAT_ID=$(skopeo inspect --tls-verify=false "docker://${TIER1_IMAGE_URL}" | jq -r '.Labels."redhat.id"')
-REDHAT_VERSION_ID=$(skopeo inspect --tls-verify=false "docker://${TIER1_IMAGE_URL}" | jq -r '.Labels."redhat.version-id"')
-CURRENT_COMPOSE_ID=$(skopeo inspect --tls-verify=false "docker://${TIER1_IMAGE_URL}" | jq -r '.Labels."redhat.compose-id"')
-
 # Dumps details about the instance running the CI job.
 function dump_runner {
     RUNNER_CPUS=$(nproc)
@@ -51,3 +46,15 @@ function retry {
     done
 }
 
+function image_inspect {
+    # shellcheck disable=SC2034
+    if [[ $TIER1_IMAGE_URL == quay* ]]; then
+        REDHAT_ID=$(skopeo inspect --tls-verify=false --creds "$QUAY_USERNAME":"$QUAY_PASSWORD" docker://"${TIER1_IMAGE_URL}" | jq -r '.Labels."redhat.id"')
+        REDHAT_VERSION_ID=$(skopeo inspect --tls-verify=false --creds "$QUAY_USERNAME":"$QUAY_PASSWORD" "docker://${TIER1_IMAGE_URL}" | jq -r '.Labels."redhat.version-id"')
+        CURRENT_COMPOSE_ID=$(skopeo inspect --tls-verify=false --creds "$QUAY_USERNAME":"$QUAY_PASSWORD" "docker://${TIER1_IMAGE_URL}" | jq -r '.Labels."redhat.compose-id"')
+    else
+        REDHAT_ID=$(skopeo inspect --tls-verify=false "docker://${TIER1_IMAGE_URL}" | jq -r '.Labels."redhat.id"')
+        REDHAT_VERSION_ID=$(skopeo inspect --tls-verify=false "docker://${TIER1_IMAGE_URL}" | jq -r '.Labels."redhat.version-id"')
+        CURRENT_COMPOSE_ID=$(skopeo inspect --tls-verify=false "docker://${TIER1_IMAGE_URL}" | jq -r '.Labels."redhat.compose-id"')
+    fi
+}


### PR DESCRIPTION
Some container image repo is private, inspecting it needs auth first. This PR addresses this scenario.