### PR TITLE
ci: add rhel-9y snapshot test triggers

### DIFF
--- a/.github/workflows/anaconda.yml
+++ b/.github/workflows/anaconda.yml
@@ -13,7 +13,8 @@ jobs:
             endsWith(github.event.comment.body, '/test-rhel95-anaconda') ||
             endsWith(github.event.comment.body, '/test-rhel94') ||
             endsWith(github.event.comment.body, '/test-rhel94-anaconda') ||
-            endsWith(github.event.comment.body, '/test-rhel94-beta-anaconda') ||
+            endsWith(github.event.comment.body, '/test-rhel9y-snapshot') ||
+            endsWith(github.event.comment.body, '/test-rhel9y-snapshot-anaconda') ||
             endsWith(github.event.comment.body, '/test-cs9') ||
             endsWith(github.event.comment.body, '/test-cs9-anaconda') ||
             endsWith(github.event.comment.body, '/test-cs9-dev') ||
@@ -207,10 +208,11 @@ jobs:
           secrets: "TIER1_IMAGE_URL=${{ secrets.CS9_DEV_TIER1_IMAGE_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};CERT_URL=${{ secrets.CERT_URL }}"
           variables: "FIRMWARE=${{ matrix.firmware }};PARTITION=${{ matrix.partition }}"
 
-  rhel94-beta-anaconda:
+  rhel9y-snapshot-anaconda:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request &&
-            (endsWith(github.event.comment.body, '/test-rhel94-beta-anaconda')) }}
+            (endsWith(github.event.comment.body, '/test-rhel9y-snapshot') ||
+            endsWith(github.event.comment.body, '/test-rhel9y-snapshot-anaconda')) }}
     continue-on-error: true
     strategy:
       matrix:
@@ -239,8 +241,8 @@ jobs:
           arch: ${{ matrix.arch }}
           tmt_context: "arch=${{ matrix.arch }}"
           update_pull_request_status: true
-          pull_request_status_name: "bootc-rhel94-beta-${{ matrix.arch }}-anaconda-${{ matrix.firmware }}-${{ matrix.partition }}"
+          pull_request_status_name: "bootc-rhel9y-snapshot-${{ matrix.arch }}-anaconda-${{ matrix.firmware }}-${{ matrix.partition }}"
           tmt_plan_regex: "${{ matrix.firmware }}-${{ matrix.partition }}"
           tf_scope: private
-          secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};RHEL_REGISTRY_URL=${{ secrets.RHEL_REGISTRY_URL }};CERT_URL=${{ secrets.CERT_URL }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};RHC_AK=${{ secrets.RHC_AK }};RHC_ORGID=${{ secrets.RHC_ORGID }}"
-          variables: "FIRMWARE=${{ matrix.firmware }};PARTITION=${{ matrix.partition }};TIER1_IMAGE_URL='quay.io/xiaofwan/rhel9-rhel_bootc-os_replace:9.4'"
+          secrets: "TIER1_IMAGE_URL=${{ secrets.RHEL9Y_SNAPSHOT_IMAGE_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};RHEL_REGISTRY_URL=${{ secrets.RHEL_REGISTRY_URL }};CERT_URL=${{ secrets.CERT_URL }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};RHC_AK=${{ secrets.RHC_AK }};RHC_ORGID=${{ secrets.RHC_ORGID }}"
+          variables: "FIRMWARE=${{ matrix.firmware }};PARTITION=${{ matrix.partition }}"

--- a/.github/workflows/bib-image.yml
+++ b/.github/workflows/bib-image.yml
@@ -13,11 +13,12 @@ jobs:
             endsWith(github.event.comment.body, '/test-rhel95-bib-image') ||
             endsWith(github.event.comment.body, '/test-rhel94') ||
             endsWith(github.event.comment.body, '/test-rhel94-bib-image') ||
+            endsWith(github.event.comment.body, '/test-rhel9y-snapshot') ||
+            endsWith(github.event.comment.body, '/test-rhel9y-snapshot-bib-image') ||
             endsWith(github.event.comment.body, '/test-cs9') ||
             endsWith(github.event.comment.body, '/test-cs9-bib-image') ||
             endsWith(github.event.comment.body, '/test-cs9-dev') ||
-            endsWith(github.event.comment.body, '/test-cs9-dev-bib-image') ||
-            endsWith(github.event.comment.body, '/test-cs9-dev-bib-cross-build')) }}
+            endsWith(github.event.comment.body, '/test-cs9-dev-bib-image')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Query author repository permissions
@@ -227,18 +228,6 @@ jobs:
             platform: vsphere
           - image_type: raw
             platform: libvirt
-          - arch: x86_64
-            build_arch: x86_64
-            runner_compose: RHEL-9.5.0-Nightly
-          - arch: aarch64
-            build_arch: aarch64
-            runner_compose: RHEL-9.5.0-Nightly
-          - arch: aarch64
-            build_arch: x86_64
-            runner_compose: Fedora-40
-          - arch: x86_64
-            build_arch: aarch64
-            runner_compose: Fedora-40
     runs-on: ubuntu-latest
 
     steps:
@@ -248,12 +237,10 @@ jobs:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
 
-      # Fedora-40 is for bib cross building test
-      # RHEL-9.5.0-Nightly is for bib non-cross building test
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: ${{ matrix.runner_compose }}
+          compose: Fedora-40
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
@@ -264,4 +251,51 @@ jobs:
           tmt_plan_regex: "${{ matrix.image_type }}"
           tf_scope: private
           secrets: "TIER1_IMAGE_URL=${{ secrets.CS9_DEV_TIER1_IMAGE_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};GOVC_URL=${{ secrets.GOVC_URL }};GOVC_USERNAME=${{ secrets.GOVC_USERNAME }};GOVC_PASSWORD=${{ secrets.GOVC_PASSWORD }}"
+          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};IMAGE_TYPE=${{ matrix.image_type }};AWS_REGION=${{ secrets.AWS_REGION }};GOVC_INSECURE=1"
+
+  rhel9y-snapshot-bib-image:
+    needs: pr-info
+    if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request &&
+            (endsWith(github.event.comment.body, '/test-rhel9y-snapshot') ||
+            endsWith(github.event.comment.body, '/test-rhel9y-snapshot-bib-image')) }}
+    continue-on-error: true
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+        image_type: [ami, qcow2, vmdk, raw]
+        exclude:
+          - arch: aarch64
+            image_type: vmdk
+        include:
+          - image_type: ami
+            platform: aws
+          - image_type: qcow2
+            platform: libvirt
+          - image_type: vmdk
+            platform: vsphere
+          - image_type: raw
+            platform: libvirt
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
+        with:
+          ref: ${{ needs.pr-info.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Run the tests
+        uses: sclorg/testing-farm-as-github-action@v1
+        with:
+          compose: RHEL-9.4.0-Nightly
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: ${{ needs.pr-info.outputs.repo_url }}
+          git_ref: ${{ needs.pr-info.outputs.ref }}
+          arch: ${{ matrix.arch }}
+          tmt_context: "arch=${{ matrix.arch }}"
+          update_pull_request_status: true
+          pull_request_status_name: "bootc-rhel9y-snapshot-${{ matrix.arch }}-bib-${{ matrix.image_type }}"
+          tmt_plan_regex: "${{ matrix.image_type }}"
+          tf_scope: private
+          secrets: "TIER1_IMAGE_URL=${{ secrets.RHEL9Y_SNAPSHOT_IMAGE_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};GOVC_URL=${{ secrets.GOVC_URL }};GOVC_USERNAME=${{ secrets.GOVC_USERNAME }};GOVC_PASSWORD=${{ secrets.GOVC_PASSWORD }};RHC_AK=${{ secrets.RHC_AK }};RHC_ORGID=${{ secrets.RHC_ORGID }}"
           variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};IMAGE_TYPE=${{ matrix.image_type }};AWS_REGION=${{ secrets.AWS_REGION }};GOVC_INSECURE=1"

--- a/.github/workflows/os-replace.yml
+++ b/.github/workflows/os-replace.yml
@@ -13,7 +13,8 @@ jobs:
             endsWith(github.event.comment.body, '/test-rhel95-replace') ||
             endsWith(github.event.comment.body, '/test-rhel94') ||
             endsWith(github.event.comment.body, '/test-rhel94-replace') ||
-            endsWith(github.event.comment.body, '/test-rhel94-beta-replace') ||
+            endsWith(github.event.comment.body, '/test-rhel9y-snapshot') ||
+            endsWith(github.event.comment.body, '/test-rhel9y-snapshot-replace') ||
             endsWith(github.event.comment.body, '/test-cs9') ||
             endsWith(github.event.comment.body, '/test-cs9-replace') ||
             endsWith(github.event.comment.body, '/test-cs9-dev') ||
@@ -221,18 +222,22 @@ jobs:
           secrets: "TIER1_IMAGE_URL=${{ secrets.CS9_DEV_TIER1_IMAGE_URL }};OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};BEAKER_KEYTAB_B64=${{ secrets.BEAKER_KEYTAB_B64 }};BEAKER_CLIENT_B64=${{ secrets.BEAKER_CLIENT_B64 }};KRB5_CONF_B64=${{ secrets.KRB5_CONF_B64 }};AZURE_SECRET=${{ secrets.AZURE_SECRET }}"
           variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};FIRMWARE=${{ matrix.firmware }};AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }};AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }};AZURE_TENANT=${{ secrets.AZURE_TENANT }}"
 
-  rhel94-beta-replace:
+  rhel9y-snapshot-replace:
     needs: pr-info
     if: ${{ needs.pr-info.outputs.allowed_user == 'true' && github.event.issue.pull_request &&
-            (endsWith(github.event.comment.body, '/test-rhel94-beta-replace')) }}
+            (endsWith(github.event.comment.body, '/test-rhel9y-snapshot') ||
+            endsWith(github.event.comment.body, '/test-rhel9y-snapshot-replace')) }}
     continue-on-error: true
     strategy:
       matrix:
         arch: [x86_64]
-        platform: [openstack, gcp, aws, libvirt]
+        platform: [openstack, gcp, aws, azure, libvirt, beaker]
         include:
           - arch: aarch64
             platform: aws
+          - arch: x86_64
+            platform: beaker
+            firmware: bios
     runs-on: ubuntu-latest
 
     steps:
@@ -252,8 +257,8 @@ jobs:
           arch: ${{ matrix.arch }}
           tmt_context: "arch=${{ matrix.arch }}"
           update_pull_request_status: true
-          pull_request_status_name: "bootc-rhel94-beta-${{ matrix.arch }}-replace-${{ matrix.platform }}"
+          pull_request_status_name: "bootc-rhel9y-snapshot-${{ matrix.arch }}-replace-${{ matrix.platform }}"
           tmt_plan_regex: "${{ matrix.platform }}"
           tf_scope: private
-          secrets: "OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};RHEL_REGISTRY_URL=${{ secrets.RHEL_REGISTRY_URL }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};RHC_AK=${{ secrets.RHC_AK }};RHC_ORGID=${{ secrets.RHC_ORGID }}"
-          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};TIER1_IMAGE_URL='quay.io/xiaofwan/rhel9-rhel_bootc-os_replace:9.4'"
+          secrets: "TIER1_IMAGE_URL=${{ secrets.RHEL9Y_SNAPSHOT_IMAGE_URL }};OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};RHEL_REGISTRY_URL=${{ secrets.RHEL_REGISTRY_URL }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};RHC_AK=${{ secrets.RHC_AK }};RHC_ORGID=${{ secrets.RHC_ORGID }}"
+          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }}"


### PR DESCRIPTION
This PR added rhel-9y snapshot image test trigger. That'll be easy to trigger snapshot or any scratch image test.

- `/test-rhel9y-snapshot` triggers `bootc install`, `anaconda install` and `bib` tests
- `/test-rhel9y-snapshot-anaconda` triggers `anaconda install` test
- `/test-rhel9y-snapshot-bib-image` triggers `bib` test
- `/test-rhel9y-snapshot-replace` triggers `bootc install` test