### PR TITLE
test: add beaker autopart with lvm support

### DIFF
--- a/.github/workflows/os-replace.yml
+++ b/.github/workflows/os-replace.yml
@@ -61,12 +61,14 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64]
-        platform: [openstack, gcp, aws, azure, libvirt, bare]
+        platform: [openstack, gcp, aws, azure, libvirt, beaker, bare]
         include:
           - arch: aarch64
             platform: aws
           - arch: aarch64
             platform: bare
+          - arch: aarch64
+            platform: beaker
     runs-on: ubuntu-latest
 
     steps:
@@ -90,7 +92,7 @@ jobs:
           tmt_plan_regex: "${{ matrix.platform }}"
           tf_scope: private
           secrets: "TIER1_IMAGE_URL=${{ secrets.RHEL95_TIER1_IMAGE_URL }};OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};RHEL_REGISTRY_URL=${{ secrets.RHEL_REGISTRY_URL }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};RHC_AK=${{ secrets.RHC_AK }};RHC_ORGID=${{ secrets.RHC_ORGID }};BEAKER_KEYTAB_B64=${{ secrets.BEAKER_KEYTAB_B64 }};BEAKER_CLIENT_B64=${{ secrets.BEAKER_CLIENT_B64 }};KRB5_CONF_B64=${{ secrets.KRB5_CONF_B64 }};AZURE_SECRET=${{ secrets.AZURE_SECRET }}"
-          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};FIRMWARE=${{ matrix.firmware }};AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }};AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }};AZURE_TENANT=${{ secrets.AZURE_TENANT }}"
+          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }};AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }};AZURE_TENANT=${{ secrets.AZURE_TENANT }}"
 
   rhel94-replace:
     needs: pr-info
@@ -105,9 +107,8 @@ jobs:
         include:
           - arch: aarch64
             platform: aws
-          - arch: x86_64
+          - arch: aarch64
             platform: beaker
-            firmware: bios
     runs-on: ubuntu-latest
 
     steps:
@@ -131,7 +132,7 @@ jobs:
           tmt_plan_regex: "${{ matrix.platform }}"
           tf_scope: private
           secrets: "TIER1_IMAGE_URL=${{ secrets.RHEL94_TIER1_IMAGE_URL }};OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};RHEL_REGISTRY_URL=${{ secrets.RHEL_REGISTRY_URL }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};RHC_AK=${{ secrets.RHC_AK }};RHC_ORGID=${{ secrets.RHC_ORGID }};BEAKER_KEYTAB_B64=${{ secrets.BEAKER_KEYTAB_B64 }};BEAKER_CLIENT_B64=${{ secrets.BEAKER_CLIENT_B64 }};KRB5_CONF_B64=${{ secrets.KRB5_CONF_B64 }};AZURE_SECRET=${{ secrets.AZURE_SECRET }}"
-          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};FIRMWARE=${{ matrix.firmware }};AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }};AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }};AZURE_TENANT=${{ secrets.AZURE_TENANT }}"
+          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }};AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }};AZURE_TENANT=${{ secrets.AZURE_TENANT }}"
 
   cs9-replace:
     needs: pr-info
@@ -146,9 +147,8 @@ jobs:
         include:
           - arch: aarch64
             platform: aws
-          - arch: x86_64
+          - arch: aarch64
             platform: beaker
-            firmware: bios
     runs-on: ubuntu-latest
 
     steps:
@@ -172,7 +172,7 @@ jobs:
           tmt_plan_regex: "${{ matrix.platform }}"
           tf_scope: private
           secrets: "TIER1_IMAGE_URL=${{ secrets.CS9_TIER1_IMAGE_URL }};OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};BEAKER_KEYTAB_B64=${{ secrets.BEAKER_KEYTAB_B64 }};BEAKER_CLIENT_B64=${{ secrets.BEAKER_CLIENT_B64 }};KRB5_CONF_B64=${{ secrets.KRB5_CONF_B64 }};AZURE_SECRET=${{ secrets.AZURE_SECRET }}"
-          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};FIRMWARE=${{ matrix.firmware }};AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }};AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }};AZURE_TENANT=${{ secrets.AZURE_TENANT }}"
+          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }};AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }};AZURE_TENANT=${{ secrets.AZURE_TENANT }}"
 
   cs9-dev-replace:
     needs: pr-info
@@ -183,12 +183,14 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64]
-        platform: [openstack, gcp, aws, azure, libvirt, bare]
+        platform: [openstack, gcp, aws, azure, libvirt, beaker, bare]
         include:
           - arch: aarch64
             platform: aws
           - arch: aarch64
             platform: bare
+          - arch: aarch64
+            platform: beaker
     runs-on: ubuntu-latest
 
     steps:
@@ -212,7 +214,7 @@ jobs:
           tmt_plan_regex: "${{ matrix.platform }}"
           tf_scope: private
           secrets: "TIER1_IMAGE_URL=${{ secrets.CS9_DEV_TIER1_IMAGE_URL }};OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};BEAKER_KEYTAB_B64=${{ secrets.BEAKER_KEYTAB_B64 }};BEAKER_CLIENT_B64=${{ secrets.BEAKER_CLIENT_B64 }};KRB5_CONF_B64=${{ secrets.KRB5_CONF_B64 }};AZURE_SECRET=${{ secrets.AZURE_SECRET }}"
-          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};FIRMWARE=${{ matrix.firmware }};AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }};AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }};AZURE_TENANT=${{ secrets.AZURE_TENANT }}"
+          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }};AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }};AZURE_TENANT=${{ secrets.AZURE_TENANT }}"
 
   rhel9y-snapshot-replace:
     needs: pr-info
@@ -227,9 +229,8 @@ jobs:
         include:
           - arch: aarch64
             platform: aws
-          - arch: x86_64
+          - arch: aarch64
             platform: beaker
-            firmware: bios
     runs-on: ubuntu-latest
 
     steps:
@@ -253,4 +254,4 @@ jobs:
           tmt_plan_regex: "${{ matrix.platform }}"
           tf_scope: private
           secrets: "TIER1_IMAGE_URL=${{ secrets.RHEL9Y_SNAPSHOT_IMAGE_URL }};OS_USERNAME=${{ secrets.OS_USERNAME }};OS_PASSWORD=${{ secrets.OS_PASSWORD }};OS_AUTH_URL=${{ secrets.OS_AUTH_URL }};QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};QUAY_SECRET=${{ secrets.QUAY_SECRET }};RHEL_REGISTRY_URL=${{ secrets.RHEL_REGISTRY_URL }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};GCP_SERVICE_ACCOUNT_FILE_B64=${{ secrets.GCP_SERVICE_ACCOUNT_FILE_B64 }};AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }};AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }};CERT_URL=${{ secrets.CERT_URL }};RHC_AK=${{ secrets.RHC_AK }};RHC_ORGID=${{ secrets.RHC_ORGID }};BEAKER_KEYTAB_B64=${{ secrets.BEAKER_KEYTAB_B64 }};BEAKER_CLIENT_B64=${{ secrets.BEAKER_CLIENT_B64 }};KRB5_CONF_B64=${{ secrets.KRB5_CONF_B64 }};AZURE_SECRET=${{ secrets.AZURE_SECRET }}"
-          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};FIRMWARE=${{ matrix.firmware }};AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }};AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }};AZURE_TENANT=${{ secrets.AZURE_TENANT }}"
+          variables: "PLATFORM=${{ matrix.platform }};ARCH=${{ matrix.arch }};OS_PROJECT_NAME=${{ secrets.OS_PROJECT_NAME }};OS_USER_DOMAIN_NAME=${{ secrets.OS_USER_DOMAIN_NAME }};OS_PROJECT_DOMAIN_NAME=${{ secrets.OS_PROJECT_DOMAIN_NAME }};GCP_PROJECT=${{ secrets.GCP_PROJECT }};AWS_REGION=${{ secrets.AWS_REGION }};AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }};AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }};AZURE_TENANT=${{ secrets.AZURE_TENANT }}"

--- a/playbooks/deploy-beaker.yaml
+++ b/playbooks/deploy-beaker.yaml
@@ -8,7 +8,6 @@
     ssh_user: ""
     ssh_key_pub: ""
     inventory_file: ""
-    firmware: "{{ lookup('env', 'FIRMWARE') | default('uefi', true) }}"
     beaker_family:
       rhel-9-4: RedHatEnterpriseLinux9
       rhel-9-5: RedHatEnterpriseLinux9

--- a/playbooks/templates/beaker-job.j2
+++ b/playbooks/templates/beaker-job.j2
@@ -11,15 +11,7 @@ user --name={{ ssh_user }} --groups=wheel --iscrypted
 sshkey --username={{ ssh_user }} "{{ lookup('ansible.builtin.file', ssh_key_pub) }}"
 zerombr
 clearpart --all --initlabel --disklabel=gpt
-{% if firmware == 'uefi' or arch == 'aarch64' %}
-part /boot/efi --size=100  --fstype=efi
-part /boot     --size=1000  --fstype=ext4 --label=boot
-part pv.01 --grow
-volgroup bootc pv.01
-logvol / --vgname=bootc --fstype=xfs --size=10000 --name=root
-{% else %}
-autopart --type=plain --fstype=xfs
-{% endif %}
+autopart --type=lvm --fstype=xfs
 %packages
 podman
 python3
@@ -41,9 +33,6 @@ echo -e '{{ ssh_user }}\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
         <and>
           <arch op="=" value="{{ arch }}"/>
           <hypervisor op="=" value=""/>
-{% if firmware == 'uefi' and arch == 'x86_64' %}
-          <key_value key="NETBOOT_METHOD" op="=" value="efigrub"/>
-{% endif %}
         </and>
       </hostRequires>
       <partitions/>


### PR DESCRIPTION
This PR will add LVM test in bootc install on beaker. bootc install will deploy on a beaker server deployed by autopart with `--type=lvm`.