### PR TITLE
test: add bootc install to-disk test

### DIFF
--- a/.github/workflows/bib-image.yml
+++ b/.github/workflows/bib-image.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-        image_type: [ami, qcow2, vmdk]
+        image_type: [ami, qcow2, vmdk, raw, to-disk]
         exclude:
           - arch: aarch64
             image_type: vmdk
@@ -72,6 +72,10 @@ jobs:
             platform: libvirt
           - image_type: vmdk
             platform: vsphere
+          - image_type: raw
+            platform: libvirt
+          - image_type: to-disk
+            platform: libvirt
     runs-on: ubuntu-latest
 
     steps:
@@ -106,7 +110,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-        image_type: [ami, qcow2, vmdk, raw]
+        image_type: [ami, qcow2, vmdk, raw, to-disk]
         exclude:
           - arch: aarch64
             image_type: vmdk
@@ -118,6 +122,8 @@ jobs:
           - image_type: vmdk
             platform: vsphere
           - image_type: raw
+            platform: libvirt
+          - image_type: to-disk
             platform: libvirt
     runs-on: ubuntu-latest
 
@@ -153,7 +159,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-        image_type: [ami, qcow2, vmdk, raw]
+        image_type: [ami, qcow2, vmdk, raw, to-disk]
         exclude:
           - arch: aarch64
             image_type: vmdk
@@ -165,6 +171,8 @@ jobs:
           - image_type: vmdk
             platform: vsphere
           - image_type: raw
+            platform: libvirt
+          - image_type: to-disk
             platform: libvirt
     runs-on: ubuntu-latest
 
@@ -200,7 +208,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-        image_type: [ami, qcow2, vmdk, raw]
+        image_type: [ami, qcow2, vmdk, raw, to-disk]
         build_arch: [x86_64, aarch64]
         exclude:
           - image_type: vmdk
@@ -219,6 +227,12 @@ jobs:
           - image_type: raw
             arch: aarch64
             build_arch: x86_64
+          - image_type: to-disk
+            arch: x86_64
+            build_arch: aarch64
+          - image_type: to-disk
+            arch: aarch64
+            build_arch: x86_64
         include:
           - image_type: ami
             platform: aws
@@ -227,6 +241,8 @@ jobs:
           - image_type: vmdk
             platform: vsphere
           - image_type: raw
+            platform: libvirt
+          - image_type: to-disk
             platform: libvirt
           - arch: x86_64
             build_arch: x86_64
@@ -275,7 +291,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-        image_type: [ami, qcow2, vmdk, raw]
+        image_type: [ami, qcow2, vmdk, raw, to-disk]
         exclude:
           - arch: aarch64
             image_type: vmdk
@@ -287,6 +303,8 @@ jobs:
           - image_type: vmdk
             platform: vsphere
           - image_type: raw
+            platform: libvirt
+          - image_type: to-disk
             platform: libvirt
     runs-on: ubuntu-latest
 

--- a/bib-image.sh
+++ b/bib-image.sh
@@ -123,7 +123,7 @@ sudo podman build --platform "$BUILD_PLATFORM" --tls-verify=false --retry=5 --re
 [[ $- =~ x ]] && debug=1 && set +x
 sed "s/REPLACE_ME/${QUAY_SECRET}/g" files/auth.template | tee auth.json > /dev/null
 [[ $debug == 1 ]] && set -x
-podman build --platform "$BUILD_PLATFORM" --tls-verify=false --retry=5 --retry-delay=10 --from "localhost/${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" --secret id=creds,src=./auth.json -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" examples/container-auth
+sudo podman build --platform "$BUILD_PLATFORM" --tls-verify=false --retry=5 --retry-delay=10 --from "localhost/${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" --secret id=creds,src=./auth.json -t "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" examples/container-auth
 
 greenprint "Push $TEST_OS installation container image"
 sudo podman push --tls-verify=false --quiet "${TEST_IMAGE_NAME}:${QUAY_REPO_TAG}" "$TEST_IMAGE_URL"
@@ -357,6 +357,34 @@ EOF
 
         greenprint "Clean up userdata.yaml and metadata.yaml"
         rm -f userdata.yaml metadata.yaml
+        ;;
+    "to-disk")
+        greenprint "💾 Create disk.raw"
+        sudo truncate -s 10G disk.raw
+
+        greenprint "bootc install to disk.raw"
+        sudo podman run \
+            --rm \
+            --privileged \
+            --pid=host \
+            --security-opt label=type:unconfined_t \
+            -v /var/lib/containers:/var/lib/containers \
+            -v /dev:/dev \
+            -v .:/output \
+            "$TEST_IMAGE_URL" \
+            bootc install to-disk --generic-image --via-loopback /output/disk.raw
+
+        sudo qemu-img convert -f raw ./disk.raw -O qcow2 "/var/lib/libvirt/images/disk.qcow2"
+
+        greenprint "Deploy $IMAGE_TYPE instance"
+        ansible-playbook -v \
+            -i "$INVENTORY_FILE" \
+            -e test_os="$TEST_OS" \
+            -e ssh_key_pub="$SSH_KEY_PUB" \
+            -e ssh_user="$SSH_USER" \
+            -e inventory_file="$INVENTORY_FILE" \
+            -e bib="true" \
+            "playbooks/deploy-libvirt.yaml"
         ;;
     *)
         redprint "Variable IMAGE_TYPE has to be defined"

--- a/tmt/plans/bib-image.fmf
+++ b/tmt/plans/bib-image.fmf
@@ -121,3 +121,29 @@ execute:
           memory: ">= 6 GB"
           virtualization:
             is-supported: true
+
+/to-disk:
+  summary: Use bib generate raw image and test locally (nested)
+  tag: to-disk
+  environment+:
+    PLATFORM: libvirt
+    IMAGE_TYPE: to-disk
+    LAYERED_IMAGE: cloud-init
+  prepare+:
+    - how: install
+      package:
+        - qemu-img
+        - qemu-kvm
+        - libvirt
+        - virt-install
+  adjust+:
+    - when: arch == ppc64le
+      enabled: false
+    - when: arch == x86_64 or arch == aarch64
+      provision+:
+        hardware:
+          cpu:
+            processors: ">= 2"
+          memory: ">= 6 GB"
+          virtualization:
+            is-supported: true


### PR DESCRIPTION
This PR adds `bootc install to-disk` test. I know this test should be in `os-replace.sh`. But the test code will become duplicated and not easy to read if add into `os-replace.sh`. The best solution is to add the test into `bib-image.sh`. Simple code change.

I'll rename `bib-image.sh` to `image.sh` to test all kinds of images which can be built by `bib` or `bootc install to-disk`.

Testing Farm test result for this PR: http://artifacts.osci.redhat.com/testing-farm/a4d36b91-162a-4401-b2d1-cd418382a7f0