### PR TITLE
test: add both public and private image test for bib

### DIFF
--- a/bib-image.sh
+++ b/bib-image.sh
@@ -17,8 +17,10 @@ if [[ ${TIER1_IMAGE_URL} =~ bootc-image-builder ]]; then
     BIB_IMAGE_URL=$TIER1_IMAGE_URL
     TIER1_IMAGE_URL=${RHEL_REGISTRY_URL}/rhel9-rhel_bootc:rhel-${VERSION}
 else
-    if [[ "$REDHAT_VERSION_ID" == "9.4" ]]; then
-        BIB_IMAGE_URL="${BIB_IMAGE_URL:-${RHEL_REGISTRY_URL}/rhel9-rhel_bootc-image-builder:rhel-${REDHAT_VERSION_ID}}"
+    # Good suggestion https://github.com/virt-s1/bootc-workflow-test/pull/281#pullrequestreview-2024981254
+    # Both RHEL 9.4 and 9.5 will use 9.4 bib image to test 9.4 bib image
+    if [[ "$REDHAT_ID" == "rhel" ]]; then
+        BIB_IMAGE_URL="${BIB_IMAGE_URL:-${RHEL_REGISTRY_URL}/rhel9-rhel_bootc-image-builder:rhel-9.4}"
     else
         BIB_IMAGE_URL="${BIB_IMAGE_URL:-quay.io/centos-bootc/bootc-image-builder:latest}"
     fi

--- a/playbooks/rollback.yaml
+++ b/playbooks/rollback.yaml
@@ -63,6 +63,8 @@
           when:
             - air_gapped_dir | default('') == ""
             - "'localhost' not in result_bootc_status.stdout"
+          # workaround bug https://issues.redhat.com/browse/RHEL-34641
+          ignore_errors: true
 
         - name: check installed package
           shell: rpm -qa | sort


### PR DESCRIPTION
This PR will test both public image (CentOS Stream and Fedora images) and private image (RHEL image) in bib image test.
Due to issue https://issues.redhat.com/browse/RHEL-34054, a workaround (`--local` and `localhost/image`) has to be used to build private image with bib.