### PR TITLE
Run bootc install test on RHEL 9.5 TF runner and add --rootfs in bib for fedora image

### DIFF
--- a/.github/workflows/os-replace.yml
+++ b/.github/workflows/os-replace.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: Fedora-40
+          compose: RHEL-9.5.0-Nightly
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
@@ -283,7 +283,7 @@ jobs:
       - name: Run the tests
         uses: sclorg/testing-farm-as-github-action@v1
         with:
-          compose: Fedora-40
+          compose: RHEL-9.5.0-Nightly
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}

--- a/playbooks/check-system.yaml
+++ b/playbooks/check-system.yaml
@@ -177,11 +177,12 @@
       when: fstype != "btrfs"
 
     # btrfs defines subvolume /root in fedora
+    # but for bootc install to-disk will set btrfs subvolume /
     - name: /var mount point checking - btrfs
       block:
         - assert:
             that:
-              - result_var_mount_point.stdout == var_mount_path
+              - (result_var_mount_point.stdout == var_mount_path_1) or (result_var_mount_point.stdout == var_mount_path_2))
             fail_msg: "/var does not mount on {{ var_mount_path }}"
             success_msg: "/var mounts on {{ var_mount_path }}"
       always:
@@ -192,7 +193,8 @@
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
       vars:
-        var_mount_path: "{{ device_name }}[/root/ostree/deploy/{{ osname }}/var]"
+        var_mount_path_1: "{{ device_name }}[/root/ostree/deploy/{{ osname }}/var]"
+        var_mount_path_2: "{{ device_name }}[/ostree/deploy/{{ osname }}/var]"
       when: fstype == "btrfs"
 
     # case: check /var mount status


### PR DESCRIPTION
This PR will change Fedora bib test runner to RHEL 9.5 runner for stability and openstack client install issue.
And this PR also add `--rootfs` in bib because fedora image does not include rootfs configuration in image.