### PR TITLE
test: add fedora tag for fedora image CI

### DIFF
--- a/tmt/plans/anaconda.fmf
+++ b/tmt/plans/anaconda.fmf
@@ -50,6 +50,7 @@ execute:
 
 /anaconda-uefi-btrfs:
   summary: Run anaconda test locally (nested)
+  tag: fedora
   environment+:
     FIRMWARE: uefi
     PARTITION: btrfs
@@ -80,6 +81,7 @@ execute:
 
 /anaconda-bios-btrfs:
   summary: Run anaconda test locally (nested)
+  tag: fedora
   environment+:
     FIRMWARE: bios
     PARTITION: btrfs

--- a/tmt/plans/bib-image.fmf
+++ b/tmt/plans/bib-image.fmf
@@ -83,7 +83,7 @@ execute:
 
 /qcow2:
   summary: Use bib generate qcow2 image and test locally (nested)
-  tag: [libvirt, stable, bib]
+  tag: [libvirt, stable, bib, fedora]
   environment+:
     CROSS_ARCH: False
     PLATFORM: libvirt

--- a/tmt/plans/os-replace.fmf
+++ b/tmt/plans/os-replace.fmf
@@ -91,7 +91,7 @@ execute:
 
 /libvirt:
   summary: Run os-replace test locally (nested)
-  tag: [libvirt, stable]
+  tag: [libvirt, stable, fedora]
   environment+:
     PLATFORM: libvirt
     LAYERED_IMAGE: qemu-guest-agent


### PR DESCRIPTION
The new `fedora` tag is for fedora base image CI https://gitlab.com/fedora/bootc/base-image.