### PR TITLE
test: skip persistent log test on fedora 41

### DIFF
--- a/playbooks/check-system.yaml
+++ b/playbooks/check-system.yaml
@@ -598,7 +598,6 @@
             failed_counter: "{{ failed_counter | int + 1 }}"
 
     # case: check persistent log in system
-    # Skipped for RHEL test due to bug https://github.com/CentOS/centos-bootc/issues/354
     - name: check journald persistent logging
       block:
         - name: list boots
@@ -618,6 +617,8 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
+      when: ansible_facts['distribution_version'] != "41"
+      # skip f41 for issue https://gitlab.com/fedora/bootc/base-images/-/issues/10
 
     # case: check reboot times
     - name: check reboot times


### PR DESCRIPTION
workaround https://gitlab.com/fedora/bootc/base-images/-/issues/10